### PR TITLE
Fix smallgen to only generate model / dao with flag `database` only

### DIFF
--- a/dbmeta/meta.go
+++ b/dbmeta/meta.go
@@ -692,7 +692,7 @@ func FindInSlice(slice []string, val string) (int, bool) {
 }
 
 // LoadTableInfo load table info from db connection, and list of tables
-func LoadTableInfo(db *sql.DB, dbTables []TableSchemaAndName, excludeDbTables []string, conf *Config) map[string]*ModelInfo {
+func LoadTableInfo(db *sql.DB, schema *string, dbTables []TableSchemaAndName, excludeDbTables []string, conf *Config) map[string]*ModelInfo {
 
 	tableInfos := make(map[string]*ModelInfo)
 
@@ -703,6 +703,11 @@ func LoadTableInfo(db *sql.DB, dbTables []TableSchemaAndName, excludeDbTables []
 		_, ok := FindInSlice(excludeDbTables, tableSchemaAndName.TableName)
 		if ok {
 			fmt.Printf("Skipping excluded table %v\n", tableSchemaAndName)
+			continue
+		}
+
+		if *schema != "" && tableSchemaAndName.TableSchema != *schema {
+			fmt.Printf("Skipping unmatched schema %v: %v\n", *schema, tableSchemaAndName)
 			continue
 		}
 

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/cresta/jimsmart-schema"
+	schema "github.com/cresta/jimsmart-schema"
 	_ "github.com/denisenkom/go-mssqldb"
 	"github.com/droundy/goopt"
 	"github.com/gobuffalo/packd"
@@ -303,7 +303,7 @@ func main() {
 		}
 	}
 
-	tableInfos = dbmeta.LoadTableInfo(db, dbTables, excludeDbTables, conf)
+	tableInfos = dbmeta.LoadTableInfo(db, sqlDatabase, dbTables, excludeDbTables, conf)
 
 	if len(tableInfos) == 0 {
 		fmt.Print(au.Red(fmt.Sprintf("No tables loaded\n")))


### PR DESCRIPTION
```
go run . \
        --sqltype=postgres \
        --connstr="host=localhost user=testuser password=abc123 dbname=testdb port=9998 sslmode=disable TimeZone=America/Los_Angeles" \
        --database=historic \
        --gorm --generate-dao \
        --module=github.com/cresta/historic-analytics/gen/go \
        --out=../historic-analytics/gen/go \
        --overwrite \
        --templateDir=../sql-schema/gen/go/template \
        --mapping=../sql-schema/extra.json
Skipping unmatched schema historic: app.action_annotations
...
Skipping unmatched schema historic: app.user_manager_materialized
Generating code for the following tables (6)
[0] historic.agent_behavior_hourly_conversation_stats
[1] historic.agent_hourly_conversation_stats
[2] historic.conversation_duration_bins
[3] historic.mv_all_users_with_teams
[4] historic.mv_chats_count
[5] historic.mv_valid_teams
```